### PR TITLE
Update Alexa.NET and added a cache for the certificate

### DIFF
--- a/Alexa.NET.Security.Functions/Alexa.NET.Security.Functions.csproj
+++ b/Alexa.NET.Security.Functions/Alexa.NET.Security.Functions.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Alexa.NET" Version="1.5.7" />
+    <PackageReference Include="Alexa.NET" Version="1.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.1" />
   </ItemGroup>


### PR DESCRIPTION
- Alexa.NET package updated to version 1.13.0
- Added a cache for the certificate to reduce the time required for request verification.